### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 
 [lib]
 
-name = "vorbis-sys"
+name = "vorbis_sys"
 path = "lib.rs"
 
 [dependencies.ogg-sys]


### PR DESCRIPTION
library target names cannot contain hyphens: vorbis-sys. @pcwalton Please merge ASAP
